### PR TITLE
Include a UMD bundle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/package.json
+++ b/package.json
@@ -1,15 +1,32 @@
 {
   "name": "factorio-blueprint",
-  "version": "2.0.16",
+  "version": "2.1.0",
   "description": "Factorio Blueprints API",
   "main": "index.js",
+  "files": [
+    "dist"
+  ],
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "prepublish": "webpack -p"
   },
   "author": "DemiPixel <luke5227@gmail.com>",
+  "contributors": [
+    {
+      "name": "Ryan Davis",
+      "email": "ryepup@gmail.com"
+    }
+  ],
   "license": "ISC",
   "dependencies": {
     "prettyjson": "^1.2.1",
     "victor": "^1.1.0"
+  },
+  "devDependencies": {
+    "babel-cli": "^6.26.0",
+    "babel-core": "^6.26.0",
+    "babel-loader": "^7.1.2",
+    "babel-preset-env": "^1.6.1",
+    "webpack": "^3.8.1"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,23 @@
+
+module.exports = {
+    entry: './index.js',
+    output: {
+        filename: './dist/factorio-blueprint.min.js',
+        library: 'Blueprint',
+        libraryTarget: 'umd'
+    },
+    module: {
+        rules: [
+            {
+                test: /\.js$/,
+                exclude: /node_modules/,
+                use: {
+                    loader: 'babel-loader',
+                    options: {
+                        presets: ['babel-preset-env']
+                    }
+                }
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Use webpack + babel to make a browser-friendly UMD bundle before
publishing the package to npm.

closes #28