### PR TITLE
Provide constants to make client code easier to understand.

### DIFF
--- a/docs/classes/Blueprint.md
+++ b/docs/classes/Blueprint.md
@@ -27,6 +27,10 @@ Returns the integer for the direction up, helpful in Blueprint.createEntity()
 
 ### static LEFT
 
+### static ROTATION_NONE, ROTATION_90_CW, ROTATION_180_CW, ROTATION_270_CW, ROTATION_270_CCW, ROTATION_180_CCW, ROTATION_90_CCW
+
+Rotation parameters for the `placeBlueprint` function.
+
 ## Methods
 
 ### Blueprint([data], [opt])
@@ -75,7 +79,7 @@ Returns the newly created [Tile](./classes/Tile.md).
 
 ### placeBlueprint(otherBlueprint, position, rotations=0, allowOverlap=false)
 
-Places `otherBlueprint` at `position` (being the center of `otherBlueprint`) with `rotations` (0, 1, 2, or 3 rotating clockwise each time). `allowOverlap` works the same as in createEntity(). Clones both entities and tiles.
+Places `otherBlueprint` at `position` (being the center of `otherBlueprint`) with `rotations`; Supply one of the `Blueprint.ROTATION_*` constants. `allowOverlap` works the same as in createEntity(). Clones both entities and tiles.
 
 Returns self.
 

--- a/src/index.js
+++ b/src/index.js
@@ -77,7 +77,7 @@ class Blueprint {
     return this;
   }
 
-  placeBlueprint(bp, position, rotations, allowOverlap) { // rotations is 0, 1, 2, or 3
+  placeBlueprint(bp, position, rotations, allowOverlap) { // rotations is 0, 1, 2, 3 or any of the Blueprint.ROTATION_* constants.
     const entitiesCreated = []
     bp.entities.forEach(ent => {
       const data = ent.getData();
@@ -313,6 +313,34 @@ class Blueprint {
 
   static get LEFT() {
     return 6;
+  }
+
+  static get ROTATION_NONE() {
+    return 0;
+  }
+
+  static get ROTATION_90_CW() {
+    return 1;
+  }
+
+  static get ROTATION_180_CW() {
+    return 2;
+  }
+
+  static get ROTATION_270_CW() {
+    return 3;
+  }
+
+  static get ROTATION_270_CCW() {
+    return this.ROTATION_90_CW;
+  }
+
+  static get ROTATION_180_CCW() {
+    return this.ROTATION_180_CW;
+  }
+
+  static get ROTATION_90_CCW() {
+    return this.ROTATION_270_CW;
   }
 
   checkName(name) {


### PR DESCRIPTION
Note that the CCW constants are provided and are aliases to the relevant CW rotation.