### PR TITLE
Get travis to build and test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: node_js
+
+node_js:
+  - "12"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # factorio-blueprint
 
 [![npm version](https://badge.fury.io/js/factorio-blueprint.svg)](https://badge.fury.io/js/factorio-blueprint)
+[![Build Status](https://travis-ci.org/demipixel/factorio-blueprint.svg?branch=master)](https://travis-ci.org/demipixel/factorio-blueprint)
 
 A node.js library created to help you create, modify, and export Factorio blueprints and blueprint strings!
 


### PR DESCRIPTION
This adds a Travis CI pipeline to automatically build and run npm test on every commit.

![build-icon](https://user-images.githubusercontent.com/1082761/57487737-5b947f00-7305-11e9-8b26-eb96cdc84e19.png)

You will need to enable travis for your demipixel/factorio-blueprint repo, this can be done by going to https://travis-ci.org/ and signing in using your github account.

Example job https://travis-ci.org/blacha/factorio-blueprint/jobs/530262438