### PR TITLE
Add support for blueprint snapping

### DIFF
--- a/docs/classes/Blueprint.md
+++ b/docs/classes/Blueprint.md
@@ -17,6 +17,17 @@ Array of all entities.
 
 Name of the blueprint, can be set. Be wary of setting this to anything other than letters or numbers.
 
+### snapping
+
+Dictionary with information on grid snapping, if set. Not set by default.
+```
+{
+  grid: {x: 32, y: 32}, //size of the grid, defaults to one chunk
+  absolute: true //whether it is absolutely positioned on the world grid or relative to the first placement
+  position: {x: 1, y: 1}, //world offset of the upper left corner of the blueprint, used only with absolute positioning
+}
+```
+
 ### static UP
 
 Returns the integer for the direction up, helpful in Blueprint.createEntity()
@@ -108,6 +119,15 @@ This is helpful as `blueprint.findEntity(position).remove()` could throw an erro
 ### removeTileAtPosition(position)
 
 Removes a tile at `position`, returns the tile (or false if it was not removed)
+
+### setSnapping(size, absolute?, absolutePosition?)
+
+Sets the grid snapping for the blueprint.
+`size` Position. Size of the grid
+`absolute` Boolean (optional). Absolute positioning will align the blueprint with the world grid
+`absolutePosition` Position (optional). Offsets an absolutely positioned blueprint from the world grid
+
+Note: The value that's shown as "grid position" in the GUI is controlled by moving the center with `fixCenter()`
 
 ### fixCenter([point])
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ export default class Blueprint {
   tilePositionGrid: { [location: string]: Tile };
   version: number;
   checkWithEntityData: boolean;
+  snapping: { grid: Position, position?: Position, absolute?: boolean };
 
   constructor(data?: any, opt: BlueprintOptions = {}) {
     this.name = 'Blueprint';
@@ -89,6 +90,10 @@ export default class Blueprint {
     data.icons.forEach((icon: any) => {
       this.icons[icon.index - 1] = this.checkName(icon.signal.name);
     });
+
+    if (data['snap-to-grid']) {
+      this.setSnapping(data['snap-to-grid'], data['absolute-snapping'], data['position-relative-to-grid']);
+    }
 
     this.setIds();
 
@@ -186,15 +191,15 @@ export default class Blueprint {
       const otherEnt = ent.getOverlap(this.entityPositionGrid);
       throw new Error(
         'Entity ' +
-          data.name +
-          ' overlaps ' +
-          // @ts-ignore
-          otherEnt.name +
-          ' entity (' +
-          data.position.x +
-          ', ' +
-          data.position.y +
-          ')',
+        data.name +
+        ' overlaps ' +
+        // @ts-ignore
+        otherEnt.name +
+        ' entity (' +
+        data.position.x +
+        ', ' +
+        data.position.y +
+        ')',
       );
     }
   }
@@ -270,6 +275,14 @@ export default class Blueprint {
       tile.id = i + 1;
     });
     return this;
+  }
+
+  setSnapping(size: Position, absolute?: boolean, absolutePosition?: Position) {
+    this.snapping = {
+      grid: size,
+      absolute: absolute,
+      position: absolutePosition,
+    }
   }
 
   // Get corner/center positions
@@ -373,12 +386,12 @@ export default class Blueprint {
       .map((icon, i) => {
         return icon
           ? {
-              signal: {
-                type: entityData[icon].type || 'item',
-                name: this.fixName(icon),
-              },
-              index: i + 1,
-            }
+            signal: {
+              type: entityData[icon].type || 'item',
+              name: this.fixName(icon),
+            },
+            index: i + 1,
+          }
           : null;
       })
       .filter(Boolean);
@@ -391,6 +404,9 @@ export default class Blueprint {
         item: 'blueprint',
         version: this.version || 0,
         label: this.name,
+        "absolute-snapping": this.snapping ? this.snapping.absolute : undefined,
+        "snap-to-grid": this.snapping ? this.snapping.grid : undefined,
+        "position-relative-to-grid": this.snapping ? this.snapping.position : undefined
       },
     };
   }

--- a/test/blueprint_generate_tests.js
+++ b/test/blueprint_generate_tests.js
@@ -133,7 +133,7 @@ describe('Blueprint Generation', () => {
     });
   });
 
-  describe('inventory filters', () => {});
+  describe('inventory filters', () => { });
 
   describe('logistic request filters', () => {
     //    it('storage chest ?', () => {
@@ -257,6 +257,23 @@ describe('Blueprint Generation', () => {
     });
   });
 
+  describe('snapping', () => {
+    const bp = new Blueprint();
+    let grid = new Victor(10, 12);
+    bp.setSnapping(grid);
+    it('should default to relative snapping', () => {
+      assert.strictEqual(bp.snapping.absolute, undefined);
+    });
+    it('should save snapping information', () => {
+      assert.equal(bp.snapping.grid, grid);
+    });
+    it('should support absolute snapping', () => {
+      bp.setSnapping(grid, true);
+      assert.strictEqual(bp.snapping.absolute, true);
+    });
+
+  });
+
   describe('icons', () => {
     it('should save icons', () => {
       const bp = new Blueprint();
@@ -316,7 +333,7 @@ describe('Blueprint Generation', () => {
       };
 
       const obj = JSON.parse(JSON.stringify(bp.toObject()));
-      console.log(obj.blueprint.entities[0].control_behavior);
+
       assert.deepEqual(obj.blueprint.entities[0].control_behavior, {
         circuit_condition: {
           first_signal: {
@@ -335,6 +352,23 @@ describe('Blueprint Generation', () => {
       });
     });
   });
+});
+
+
+describe('Blueprint output', () => {
+  let bp = new Blueprint();
+  bp.name = "custom label";
+  bp.setSnapping(new Victor(10, 20), true);
+  let bpObj = bp.toObject().blueprint;
+
+  it('correnctly handles snapping size', () => {
+    assert.equal(bpObj["snap-to-grid"].x, 10);
+    assert.equal(bpObj["snap-to-grid"].y, 20);
+  });
+  it('correctly handles absolute snapping', () => {
+    assert.strictEqual(bpObj['absolute-snapping'], true);
+  });
+
 });
 
 describe('Blueprint Books', () => {

--- a/test/blueprint_parse_tests.js
+++ b/test/blueprint_parse_tests.js
@@ -316,7 +316,7 @@ describe('Blueprint Parsing', () => {
     });
   });
 
-  describe('connections', () => {});
+  describe('connections', () => { });
 
   describe('splitters', () => {
     function asserts(
@@ -391,6 +391,32 @@ describe('Blueprint Parsing', () => {
       const bp = new Blueprint(input);
       assert.equal(bp.entities[0].manualTrainsLimit, 152);
     });
+  });
+
+  describe('snapping', () => {
+    it('should preserve snapping grid size', () => {
+      // a simple loop of fast belts in a 3x3 space with relative snapping
+      const input = '0eNqd001rhDAQBuC/InOOi8bP9bY999ZjKSXq7BLQJCTZUhH/e0e9bFsp1YuSZPLwZjQj1N0djZXKQzVCi66x0nipFVRwCWj+FuhrUGPnHTBwSpjQ6/BmZTvXf0KVMBjoOTGQjVYOqtcRnLwp0c0FfjBIkvTY03Yl+nl0Fc6H3grljLY+nHGY96sWCYynNwaovPQSV24ZDO/q3tdoqeBPiIHRTq4nWAJGp2yJGJ+yaWK/NH5MozdFbqXFZl3lG3ayz+YPSb/Z6YadHrOj/9jZPjve05P8WL/59tcrjiXlP5PmG3Z5rMMbNv3Qyw2oHm4bg04QRHMvsjcdBk+kBs9aG1r6QOvWDpZxWpx5kZ95VCZ8mr4AU8k4pA==';
+      const bp = new Blueprint(input);
+      assert.equal(bp.snapping.grid.x, 3);
+      assert.equal(bp.snapping.grid.y, 3);
+
+    });
+    it('should preserve absolute snapping', () => {
+      // same as above, but with absolute snapping
+      const input = '0eNqdk8FugzAMhl8F+RwqSCm03Lrz3mCapgBuFQmSKDHTKsS7z8AO3YamlUsix/bnP048QNX26Lw2BOUADYbaa0faGijhHPH5NbKXqMKWAggIRrmYbHz1upniP6DcC7jxOgpQVbBtTxhPUY4zoSTfowBdWxOgfBkg6KtR7ZRJN4dcQhN2zDWqm6yLChSTVyY46ymeqgKDtWmQK6XjqwA0pEnjgpuN25vpuwo9B/wJEuBs0MvVZuXJ7jBrT3eHcRS/aHIbjXeW3GiP9eKVK+z9Y2x5p/QbO1thZ9vYyX/Yh8fY6SM9ybf1W66/XrFNqfypNF9hH7d1eIXNH3qegPJuDAW0ikHT/H0NVPTE3OjZWsfOd/Rh6eExzYqTLPKTTI57OY6fhfJCzw==';
+      const bp = new Blueprint(input);
+      assert.strictEqual(bp.snapping.absolute, true);
+    });
+
+  });
+  it('should preserve absolute offset', () => {
+    // as above, but offst from the absolute grid by 1, 1
+    const input =
+      '0eNqd091qgzAUB/BXkXMdS02/veuu9wZjjFhPS0CTkBzLRHz3nWhhXSdj9UbJ1y9/jp4OiqpB57UhyDsoMZy8dqStgRyOCc9fEntOCqwogIBglEvJphevy7j/E/KVgJafvQBVBFs1hGnc5fgk5OQbFOBs0JFMPVaK9BUfiGwgMib0yZoA+VsHQV+MquIGah1yGE1YcwKj6jg6q0ApeWWCs57SmA/ieVNiBPt3AWiIb8WRGwbth2nqAv1w4x/Qd+JbwOViM0ZcbPpe/NLkPI3fHLnUHk/jqpywV8/Z8i7pD3s9Ya/n2cv/2Jvn7OyZmmzn1VtOf73dvKTyMel2wt7Pq/CEzT/00AH5XcMKqBRDsVNvrZe8sJu8Wut48Yo+jDXcZ+vdQe62B7ncr2TffwEVn1DN';
+    const bp = new Blueprint(input);
+    assert.equal(bp.snapping.position.x, 1);
+    assert.equal(bp.snapping.position.y, 1);
   });
 });
 


### PR DESCRIPTION
This partially addresses #63, in which snapping is lost on blueprint import. It also adds a new method, setSnapping(), for defining snapping in a blueprint. Both relative and absolute snapping are supported, the default is relative. 
Tests for both parsing and generation are included.
