### PR TITLE
Fixed a few type discrepancies

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-  "editor.formatOnSave": true
+  "editor.formatOnSave": false
 }

--- a/docs/classes/Entity.md
+++ b/docs/classes/Entity.md
@@ -149,7 +149,7 @@ Sets the condition on an arithmetic or decider combinator.
 
 ```js
 opt = {
-  left: 'transport_belt', // Number (constant) or String (item/entity name)
+  left: 'transport_belt', // String (item/entity name)
   right: 4, // Number (constant) or String (item/entity name)
   operator: '>', // If arithmetic, +-*/, if decider, <>=
   countFromInput: true, // For decider combinator, should output count from input (or be one). Default is true

--- a/docs/classes/Entity.md
+++ b/docs/classes/Entity.md
@@ -113,7 +113,7 @@ Connect a wire (used for circuits) from one entity to another.
 
 Returns self.
 
-### removeConnection(toEntity, fromSide, toSide, color)
+### removeConnection(toEntity, { fromSide, toSide, color })
 
 Remove wire connection (if it exists). Returns self.
 

--- a/docs/classes/Entity.md
+++ b/docs/classes/Entity.md
@@ -99,13 +99,13 @@ Removes self from blueprint.
 
 Gets a Victor position of respective relative location. `entity.topLeft()` is the same as `entity.position.clone()`.
 
-### connect(toEntity, fromSide, toSide, color)
+### connect(toEntity, { fromSide, toSide, color })
 
 Connect a wire (used for circuits) from one entity to another.
 
 `toEntity` The entity we are connecting the wire to.
 
-`fromSide` The side on the current entity that we should connect the wire to. This can be `"in"` or `"out"`. `"in"` is needed for most entities (other than decider/arithmetic combinators) and `undefined` or `null` will default to `"in"`.
+`fromSide` The side on the current entity that we should connect the wire to. This can be `"in"` or `"out"`. `"in"` is needed for most entities (other than decider/arithmetic combinators) and `undefined` will default to `"in"`.
 
 `toSide` The side on the `toEntity` that we should connect the wire to.
 

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -474,17 +474,17 @@ export default class Entity {
   connect(
     ent: Entity,
     { 
-      mySide,
-      theirSide,
+      fromSide,
+      toSide,
       color 
     }: {
-      mySide?: Side
-      theirSide?: Side
+      fromSide?: Side
+      toSide?: Side
       color: Color
     }
   ) {
-    mySide = convertSide(this, mySide);
-    theirSide = convertSide(ent, theirSide);
+    fromSide = convertSide(this, fromSide);
+    toSide = convertSide(ent, toSide);
 
     const checkCombinator = (name: string) => {
       return name == 'decider_combinator' || name == 'arithmetic_combinator';
@@ -495,14 +495,14 @@ export default class Entity {
     this.connections.push({
       entity: ent,
       color: color,
-      side: mySide,
-      id: checkCombinator(ent.name) ? theirSide.toString() : undefined,
+      side: fromSide,
+      id: checkCombinator(ent.name) ? toSide.toString() : undefined,
     });
     ent.connections.push({
       entity: this,
       color: color,
-      side: theirSide,
-      id: checkCombinator(this.name) ? mySide.toString() : undefined,
+      side: toSide,
+      id: checkCombinator(this.name) ? fromSide.toString() : undefined,
     });
     return this;
   }
@@ -510,23 +510,23 @@ export default class Entity {
   // Remove a specific wire connection given all details
   removeConnection(
     ent: Entity,
-    { mySide,
-      theirSide,
+    { fromSide,
+      toSide,
       color
     }: {
-      mySide?: Side
-      theirSide?: Side
+      fromSide?: Side
+      toSide?: Side
       color: Color
     }
   ) {
-    mySide = convertSide(this, mySide);
-    theirSide = convertSide(ent, theirSide);
+    fromSide = convertSide(this, fromSide);
+    toSide = convertSide(ent, toSide);
     color = color || 'red';
 
     for (let i = 0; i < this.connections.length; i++) {
       if (
         this.connections[i].entity == ent &&
-        this.connections[i].side == mySide &&
+        this.connections[i].side == fromSide &&
         this.connections[i].color == color
       ) {
         this.connections.splice(i, 1);
@@ -536,7 +536,7 @@ export default class Entity {
     for (let i = 0; i < ent.connections.length; i++) {
       if (
         ent.connections[i].entity == this &&
-        ent.connections[i].side == theirSide &&
+        ent.connections[i].side == toSide &&
         ent.connections[i].color == color
       ) {
         ent.connections.splice(i, 1);

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -18,7 +18,7 @@ interface Connection {
 
 interface CombinatorData {
   left?: string;
-  right?: string;
+  right?: string | number;
   operator?: string;
   out?: string;
 
@@ -473,8 +473,8 @@ export default class Entity {
   // Connect current entity to another entity via wire
   connect(
     ent: Entity,
-    mySide: Side = 1,
-    theirSide: Side = 1,
+    mySide: Side | null = 1,
+    theirSide: Side | null = 1,
     color: Color = 'red',
   ) {
     mySide = convertSide(mySide, this);
@@ -1015,7 +1015,7 @@ export default class Entity {
 // Lib Functions
 
 // Convert 'in' or 'out' of wires (only combinators have both of these) to a 1 or 2.
-function convertSide(side: Side, ent: Entity) {
+function convertSide(side: Side | null, ent: Entity) {
   if (!side) return 1;
   if (side == 1 || side == 2) return side;
   else if (side == 'in' || side == 'out') {

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -473,12 +473,18 @@ export default class Entity {
   // Connect current entity to another entity via wire
   connect(
     ent: Entity,
-    mySide: Side | null = 1,
-    theirSide: Side | null = 1,
-    color: Color = 'red',
+    { 
+      mySide,
+      theirSide,
+      color 
+    }: {
+      mySide?: Side
+      theirSide?: Side
+      color: Color
+    }
   ) {
-    mySide = convertSide(mySide, this);
-    theirSide = convertSide(theirSide, ent);
+    mySide = convertSide(this, mySide);
+    theirSide = convertSide(ent, theirSide);
 
     const checkCombinator = (name: string) => {
       return name == 'decider_combinator' || name == 'arithmetic_combinator';
@@ -504,12 +510,17 @@ export default class Entity {
   // Remove a specific wire connection given all details
   removeConnection(
     ent: Entity,
-    mySide: Side = 1,
-    theirSide: Side = 1,
-    color: Color = 'red',
+    { mySide,
+      theirSide,
+      color
+    }: {
+      mySide?: Side
+      theirSide?: Side
+      color: Color
+    }
   ) {
-    mySide = convertSide(mySide, this);
-    theirSide = convertSide(theirSide, ent);
+    mySide = convertSide(this, mySide);
+    theirSide = convertSide(ent, theirSide);
     color = color || 'red';
 
     for (let i = 0; i < this.connections.length; i++) {
@@ -1015,7 +1026,7 @@ export default class Entity {
 // Lib Functions
 
 // Convert 'in' or 'out' of wires (only combinators have both of these) to a 1 or 2.
-function convertSide(side: Side | null, ent: Entity) {
+function convertSide(ent: Entity, side?: Side) {
   if (!side) return 1;
   if (side == 1 || side == 2) return side;
   else if (side == 'in' || side == 'out') {

--- a/test/blueprint_generate_tests.js
+++ b/test/blueprint_generate_tests.js
@@ -217,7 +217,7 @@ describe('Blueprint Generation', () => {
         { x: 0, y: 5 },
         Blueprint.UP,
       );
-      e1.connect(e2, null, null, 'red');
+      e1.connect(e2, { color: 'red' });
 
       const obj = bp.toObject();
 


### PR DESCRIPTION
I found three type discrepancies between the types, the code, the documentation, the tests, and the game itself.

1) `CombinatorData.right`

The documentation says it can be a string or a number, the tests show a call to setCondition with the right property of the CombinatorData parameter set to a number, the code handles number values, and the game allows a constant on the right, but the type doesn't allow for a number. Passing in data with a number produces a type error.

So I updated the type to match the documentation, the tests, the code, and the game.

2) `CombinatorData.left`

The documentation says it can be a string or a number, but the game and the code do not allow number values on the left side.

So I updated the documentation to match them.

3) `Entity.connect()` - `fromSide` and `toSide` parameters

The documentation says that null values will be handled, the code does handle null values, there is a test with null values, but the type only allows for undefined.

So I updated the type to allow null. 

I had to update convertSide to accept a null side as well, which it was already written to handle.