### PR TITLE
Add logistic connections

### DIFF
--- a/docs/classes/Entity.md
+++ b/docs/classes/Entity.md
@@ -149,7 +149,7 @@ Sets the condition on an arithmetic or decider combinator.
 
 ```js
 opt = {
-  left: 'transport_belt', // Number (constant) or String (item/entity name)
+  left: 'transport_belt', // String (item/entity name)
   right: 4, // Number (constant) or String (item/entity name)
   operator: '>', // If arithmetic, +-*/, if decider, <>=
   countFromInput: true, // For decider combinator, should output count from input (or be one). Default is true

--- a/docs/classes/Entity.md
+++ b/docs/classes/Entity.md
@@ -41,7 +41,7 @@ List of entities that this electrical pole is connected to.
 
 ### condition
 
-Condition (if the entity is a combinator).
+Condition (circuit or logistic).
 
 ### constantEnabled
 
@@ -145,7 +145,7 @@ Remove all request filters on this entity. Returns self.
 
 ### setCondition(opt)
 
-Sets the condition on an arithmetic or decider combinator.
+Sets the condition, either circuit or logistic.
 
 ```js
 opt = {
@@ -154,6 +154,17 @@ opt = {
   operator: '>', // If arithmetic, +-*/, if decider, <>=
   countFromInput: true, // For decider combinator, should output count from input (or be one). Default is true
   out: 'medium_electric_pole' // String (item/entity name)
+}
+```
+
+To set a logistic condition, specify the type as 'logistic'. If the type property is left off, it defaults to a circuit condition.
+
+```js
+opt = {
+  left: 'fast-inserter',
+  operator: '<',
+  right: 200,
+  type: 'logistic'
 }
 ```
 

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -22,7 +22,7 @@ interface CombinatorData {
   operator?: string;
   out?: string;
 
-  type?: string;
+  type?: 'logistic' | 'circuit';
 
   controlEnable?: boolean;
   readContents?: boolean;

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -998,7 +998,7 @@ export default class Entity {
                 this.name == 'arithmetic_combinator'
                   ? getCondition()
                   : undefined,
-              connect_to_logistic_network: this.condition.type === 'logistic',
+              connect_to_logistic_network: this.condition.type === 'logistic' ? true : undefined,
               [this.condition.type === 'logistic'
                 ? 'logistic_condition'
                 : 'circuit_condition']:

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -18,7 +18,7 @@ interface Connection {
 
 interface CombinatorData {
   left?: string;
-  right?: string;
+  right?: string | number;
   operator?: string;
   out?: string;
 
@@ -473,8 +473,8 @@ export default class Entity {
   // Connect current entity to another entity via wire
   connect(
     ent: Entity,
-    mySide: Side = 1,
-    theirSide: Side = 1,
+    mySide: Side | null = 1,
+    theirSide: Side | null = 1,
     color: Color = 'red',
   ) {
     mySide = convertSide(mySide, this);
@@ -1015,7 +1015,7 @@ export default class Entity {
 // Lib Functions
 
 // Convert 'in' or 'out' of wires (only combinators have both of these) to a 1 or 2.
-function convertSide(side: Side, ent: Entity) {
+function convertSide(side: Side | null, ent: Entity) {
   if (!side) return 1;
   if (side == 1 || side == 2) return side;
   else if (side == 'in' || side == 'out') {

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -22,6 +22,8 @@ interface CombinatorData {
   operator?: string;
   out?: string;
 
+  type?: string;
+
   controlEnable?: boolean;
   readContents?: boolean;
   readMode?: string;
@@ -636,6 +638,8 @@ export default class Entity {
       countFromInput: this.condition.countFromInput || opt.countFromInput,
       out: this.condition.out || opt.out,
 
+      type: this.condition.type || opt.type,
+
       controlEnable: this.condition.controlEnable || opt.controlEnable, // circuit_enable_disable, true/false
       readContents: this.condition.readContents || opt.readContents, // circuit_read_hand_contents, true/false
       readMode: this.condition.readMode || opt.readMode, // circuit_contents_read_mode, 0 or 1
@@ -983,7 +987,10 @@ export default class Entity {
                 this.name == 'arithmetic_combinator'
                   ? getCondition()
                   : undefined,
-              circuit_condition:
+              connect_to_logistic_network: this.condition.type === 'logistic',
+              [this.condition.type === 'logistic'
+                ? 'logistic_condition'
+                : 'circuit_condition']:
                 !this.name.includes('combinator') && this.condition.left
                   ? getCondition()
                   : undefined,

--- a/test/blueprint_generate_tests.js
+++ b/test/blueprint_generate_tests.js
@@ -133,7 +133,7 @@ describe('Blueprint Generation', () => {
     });
   });
 
-  describe('inventory filters', () => {});
+  describe('inventory filters', () => { });
 
   describe('logistic request filters', () => {
     //    it('storage chest ?', () => {
@@ -381,22 +381,22 @@ describe('Blueprint Generation', () => {
 
 describe('Blueprint output', () => {
   let bp = new Blueprint();
-  bp.name = 'custom label';
-  bp.description = 'custom description';
+  bp.name = "custom label";
+  bp.description = "custom description";
   bp.setSnapping(new Victor(10, 20), true);
   let bpObj = bp.toObject().blueprint;
 
   it('correctly handles blueprint labels', () => {
-    assert.equal(bpObj.label, 'custom label');
+    assert.equal(bpObj.label, "custom label");
   });
 
   it('correctly handles blueprint descriptions', () => {
-    assert.equal(bpObj.description, 'custom description');
+    assert.equal(bpObj.description, "custom description");
   });
 
   it('correnctly handles snapping size', () => {
-    assert.equal(bpObj['snap-to-grid'].x, 10);
-    assert.equal(bpObj['snap-to-grid'].y, 20);
+    assert.equal(bpObj["snap-to-grid"].x, 10);
+    assert.equal(bpObj["snap-to-grid"].y, 20);
   });
   it('correctly handles absolute snapping', () => {
     assert.strictEqual(bpObj['absolute-snapping'], true);

--- a/test/blueprint_generate_tests.js
+++ b/test/blueprint_generate_tests.js
@@ -133,7 +133,7 @@ describe('Blueprint Generation', () => {
     });
   });
 
-  describe('inventory filters', () => { });
+  describe('inventory filters', () => {});
 
   describe('logistic request filters', () => {
     //    it('storage chest ?', () => {
@@ -271,7 +271,6 @@ describe('Blueprint Generation', () => {
       bp.setSnapping(grid, true);
       assert.strictEqual(bp.snapping.absolute, true);
     });
-
   });
 
   describe('icons', () => {
@@ -342,6 +341,7 @@ describe('Blueprint Generation', () => {
           comparator: '>',
           constant: 0,
         },
+        connect_to_logistic_network: false,
         read_from_train: true,
         read_stopped_train: true,
         train_stopped_signal: {
@@ -352,31 +352,55 @@ describe('Blueprint Generation', () => {
     });
   });
 
+  describe('logistic conditions', () => {
+    it('should set logistic condition', () => {
+      const bp = new Blueprint();
+      const inserter = bp.createEntity('inserter', { x: 0, y: 0 });
+      inserter.setCondition({
+        left: 'transport-belt',
+        operator: '<',
+        right: 200,
+        type: 'logistic',
+      });
+
+      const obj = JSON.parse(JSON.stringify(bp.toObject()));
+      assert.deepEqual(obj.blueprint.entities[0].control_behavior, {
+        logistic_condition: {
+          first_signal: {
+            name: 'transport-belt',
+            type: 'item',
+          },
+          comparator: '<',
+          constant: 200,
+        },
+        connect_to_logistic_network: true,
+      });
+    });
+  });
 });
 
 describe('Blueprint output', () => {
   let bp = new Blueprint();
-  bp.name = "custom label";
-  bp.description = "custom description";
+  bp.name = 'custom label';
+  bp.description = 'custom description';
   bp.setSnapping(new Victor(10, 20), true);
   let bpObj = bp.toObject().blueprint;
 
   it('correctly handles blueprint labels', () => {
-    assert.equal(bpObj.label, "custom label");
+    assert.equal(bpObj.label, 'custom label');
   });
 
   it('correctly handles blueprint descriptions', () => {
-    assert.equal(bpObj.description, "custom description");
-  })
+    assert.equal(bpObj.description, 'custom description');
+  });
 
   it('correnctly handles snapping size', () => {
-    assert.equal(bpObj["snap-to-grid"].x, 10);
-    assert.equal(bpObj["snap-to-grid"].y, 20);
+    assert.equal(bpObj['snap-to-grid'].x, 10);
+    assert.equal(bpObj['snap-to-grid'].y, 20);
   });
   it('correctly handles absolute snapping', () => {
     assert.strictEqual(bpObj['absolute-snapping'], true);
   });
-
 });
 
 describe('Blueprint Books', () => {

--- a/test/blueprint_generate_tests.js
+++ b/test/blueprint_generate_tests.js
@@ -341,7 +341,6 @@ describe('Blueprint Generation', () => {
           comparator: '>',
           constant: 0,
         },
-        connect_to_logistic_network: false,
         read_from_train: true,
         read_stopped_train: true,
         train_stopped_signal: {


### PR DESCRIPTION
I'd really like to be able to set logistic conditions with factorio-blueprint. Here's a way that appears to work nicely and has essentially no effect on setting circuit conditions.

I added a type property to CombinatorData that can be left undefined, or set to "logistic" or "circuit".

> Side Note: I think it would make more sense to rename the type to ConditionData, since it's used for all conditions, not just on combinators.

If it's left undefined, the condition will be a circuit condition.

In data generation, I added the connect_to_logistic_network property, and put in a ternary operator to switch between naming the condition property "circuit_condition" or "logistic_condition".

I added a test for setting the logistic condition and updated the documentation to make it clear that conditions can be circuit or logistic and aren't just for combinators.