### PR TITLE
Enable dual ESM + CommonJS build support

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,12 @@
     "encode",
     "decode"
   ],
-  "main": "dist/factorio-blueprint.min.js",
+  "main": "./dist/factorio-blueprint.cjs.js",
+  "module": "./dist/factorio-blueprint.esm.js",
+  "exports": {
+    "require": "./dist/factorio-blueprint.cjs.js",
+    "import": "./dist/factorio-blueprint.esm.js"
+  },
   "types": "dist/src/index.d.ts",
   "scripts": {
     "test": "mocha",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,15 +1,8 @@
 const NodePolyfillPlugin = require('node-polyfill-webpack-plugin');
 
-module.exports = {
+const baseConfig = {
   entry: './src/index.ts',
   mode: 'production',
-  output: {
-    filename: './factorio-blueprint.min.js',
-    library: 'Blueprint',
-    libraryTarget: 'umd',
-    globalObject: 'this',
-    libraryExport: 'default',
-  },
   resolve: {
     extensions: ['.tsx', '.ts', '.js'],
   },
@@ -41,3 +34,33 @@ module.exports = {
   },
   plugins: [new NodePolyfillPlugin()],
 };
+
+module.exports = [
+  // CJS build
+  {
+    ...baseConfig,
+    output: {
+      filename: "factorio-blueprint.cjs.js",
+      library: {
+        type: "commonjs2",
+      },
+      globalObject: "this",
+    },
+  },
+
+  // ESM build
+  {
+    ...baseConfig,
+    experiments: {
+      outputModule: true,
+    },
+    output: {
+      filename: "factorio-blueprint.esm.js",
+      library: {
+        type: "module",
+      },
+      module: true,
+      globalObject: "this",
+    },
+  },
+];


### PR DESCRIPTION
This PR adds optional ESM support alongside the existing CommonJS build, without introducing any breaking changes for current users. This improves compatibility with modern Node.js + TypeScript ESM projects, which currently require workarounds due to the package being CJS-only.

In other words, the package will now support both:

```ts
require("factorio-blueprint"); // CommonJS build, as in your README
import Blueprint from "factorio-blueprint"; // ESM build
```

Before this PR, the second line would fail with:

```ts
import Blueprint from "factorio-blueprint";

const bp: Blueprint = new Blueprint();
//        ^^^^^^^^^   ^^^^^^^^^^^^^^^
// error TS2709: Cannot use namespace 'Blueprint' as a type.
// error TS2351: This expression is not constructable.
```

Here's a reproduction: https://codesandbox.io/p/devbox/frosty-feynman-z6yr93 - see that while the application works, there are type errors in `index.ts`. This is because in `tsconfig.json`, `module=NodeNext` and `moduleResolution=NodeNext`.

> [!CAUTION]
> I have a rudimentary understanding of the differences between CommonJS and ESM, but am absolutely not an expert. I did test that the output of `npm run build` makes sense as far as I understand it.